### PR TITLE
Update skiboot package name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
         clang-8 \
         lld-8 \
         llvm-8 \
-        skiboot \
+        qemu-skiboot \
         qemu-system-arm \
         qemu-system-ppc \
         qemu-system-x86 && \


### PR DESCRIPTION
The upstream (Debian) package is called skiboot-qemu. Now that the PPA
is updated to use this package we need to use the new name.

Signed-off-by: Joel Stanley <joel@jms.id.au>