### PR TITLE
travis: Bump LLVM version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ services:
 matrix:
   include:
     - name: "Development"
-      env: LLVM_VERSION=9
+      env: LLVM_VERSION=10
     - name: "Stable"
-      env: LLVM_VERSION=8
+      env: LLVM_VERSION=9
 
 script:
   - make release


### PR DESCRIPTION
I missed this because `rg` ignores `.travis.yml` by default so my search for `LLVM_VERSION` ignored this... -_-